### PR TITLE
feat: add initial CLI entry point and stub commands for spec2lambda

### DIFF
--- a/docs/cli-overview.md
+++ b/docs/cli-overview.md
@@ -1,6 +1,15 @@
 # CLI Overview
-
 The `spec2lambda` CLI is the entry point for building, evolving, and maintaining spec-driven AWS Lambda APIs. It unifies code generation, local development, and project scaffolding into a single, repeatable workflow.
+
+## CLI Stub Implementation (v1)
+
+The CLI currently supports the following commands as stubs:
+
+- `init <project-name>`: Prints a placeholder message for project initialization.
+- `generate`: Prints a placeholder message for code generation.
+- `--help`/`-h`: Shows usage information.
+
+These commands do not yet perform real work, but provide a foundation for future development. Use `npm run cli -- <command>` for local development.
 
 ## Philosophy: Template + Generator
 - **Template**: Provides a ready-to-extend TypeScript service structure, with clear boundaries between user code and generated artifacts.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,3 +23,14 @@ spec2lambda generate [--config <path>]
 - Groups handler stubs by resource (e.g., all user operations in `src/handlers/users.ts`).
 - Ensures all operationIds are stubbed and wired into the framework.
 - Never modifies user-implemented logic in existing handler functions.
+
+
+## CLI Stub Implementation (v1)
+
+The CLI currently supports the following commands as stubs:
+
+- `init <project-name>`: Prints a placeholder message for project initialization.
+- `generate`: Prints a placeholder message for code generation.
+- `--help`/`-h`: Shows usage information.
+
+These commands do not yet perform real work, but provide a foundation for future development. Use `npm run cli -- <command>` for local development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "tsup": "^8.5.1",
+        "tsx": "^4.20.6",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.48.0",
         "vitest": "^3.2.4",
@@ -5142,6 +5143,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -7681,6 +7695,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -9389,6 +9413,26 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A TypeScript template for building spec-driven AWS Lambda APIs using OpenAPI, code generation, modular handlers, and a local dev server.",
   "main": "index.js",
   "scripts": {
+    "cli": "tsx src/cli.ts",
     "codegen": "npm run codegen:types && npm run codegen:zod && npm run codegen:routes",
     "codegen:types": "openapi-typescript ./api/openapi.yml -o ./src/generated/openapi.types.ts",
     "codegen:zod": "orval --config orval.config.cjs",
@@ -45,6 +46,7 @@
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "tsup": "^8.5.1",
+    "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.48.0",
     "vitest": "^3.2.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+export async function main() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [command, ...args] = process.argv.slice(2);
+
+  switch (command) {
+    case "init":
+      console.log("[spec2lambda] TODO: implement project initialization");
+      break;
+    case "generate":
+      console.log("[spec2lambda] TODO: implement code generation");
+      break;
+    case "--help":
+    case "-h":
+    default:
+      console.log(`spec2lambda - CLI\n\nUsage:\n  spec2lambda init <project-name>\n  spec2lambda generate --config spec2lambda.config.mts\n\nCommands:\n  init         Scaffold a new Lambda service\n  generate     Run codegen based on the OpenAPI spec\n\nNote:\n  The existing local-dev server is still used separately (e.g., npm run dev).\n`);
+      if (command && command !== "--help" && command !== "-h") {
+        process.exitCode = 1;
+      }
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/cli.spec.ts
+++ b/tests/unit/cli.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+
+// This test only checks that the CLI module can be imported without error.
+describe('CLI Entrypoint', () => {
+  it('should import without throwing', async () => {
+    let cliModule;
+    let error;
+    try {
+      cliModule = await import('../../src/cli');
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeUndefined();
+    expect(cliModule).toBeDefined();
+  });
+});


### PR DESCRIPTION
This pull request introduces an initial stub implementation of the `spec2lambda` CLI, laying the groundwork for future command development. It adds a new CLI entrypoint with placeholder commands, updates documentation to reflect the new CLI, and introduces a basic test for the CLI module. Additionally, it updates the project’s dependencies and scripts to support local CLI development.

**CLI Implementation and Testing:**

* Adds a new CLI entrypoint in `src/cli.ts` with stubbed commands: `init`, `generate`, and `--help`/`-h`. Each command currently prints a placeholder message, providing a foundation for future functionality.
* Introduces a basic unit test in `tests/unit/cli.spec.ts` to ensure the CLI module can be imported without errors.

**Documentation Updates:**

* Updates `docs/cli-overview.md` and `docs/commands.md` to document the new CLI stub implementation, listing available commands and usage instructions. [[1]](diffhunk://#diff-e52c22ca79ba2a1b951b4502975a5e729dc4e9e02cf519cd939df5b8d2542e4dL2-R13) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR26-R36)

**Project Configuration:**

* Adds a new `cli` script to `package.json` for running the CLI locally using `tsx`.
* Adds `tsx` as a development dependency in `package.json` to enable TypeScript CLI execution.