### PR TITLE
feat: add package template command to copy starter files and update b…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
   },
   "scripts": {
     "cli": "tsx src/cli.ts",
+    "build:template": "tsx src/scripts/packageTemplate.ts",
     "codegen": "npm run cli -- generate",
     "codegen:types": "openapi-typescript ./api/openapi.yml -o ./src/generated/openapi.types.ts",
     "codegen:zod": "orval --config orval.config.cjs",
     "codegen:contracts": "npm run codegen:types && npm run codegen:zod",
     "test": "vitest --run",
     "typecheck": "tsc --noEmit",
-    "build": "tsc",
+    "build": "tsc && npm run build:template",
     "lint": "eslint . --ext .ts,.js,.cjs,.mjs"
   },
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "url";
-import { initProject, defaultManifest } from "./scripts/initProject.js";
+import { initProject } from "./scripts/initProject.js";
+import { defaultManifest } from "./scripts/packageTemplate.js";
 import { runGenerateCLI } from "./runGenerateCLI.js";
 import * as fs from "fs";
 import { realpathSync } from "fs";
@@ -62,7 +63,7 @@ export class Cli {
     }
   }
 }
-function isMainModule(): boolean {
+export function isMainModule(): boolean {
   try {
     const modulePath = normalize(realpathSync(fileURLToPath(import.meta.url)));
     if (!process.argv[1]) return false;

--- a/src/scripts/packageTemplate.ts
+++ b/src/scripts/packageTemplate.ts
@@ -1,0 +1,111 @@
+import { fileURLToPath } from "url";
+import * as fs from "fs";
+import * as path from "path";
+export interface ManifestEntry {
+  /** Output path for the copied file */
+  path: string;
+  /** Source file to copy from (relative to project root) */
+  source: string;
+}
+
+export type Manifest = ManifestEntry[];
+
+export const defaultManifest: Manifest = [
+  {
+    path: "src/handlers/HttpRouter.ts",
+    source: "src/handlers/HttpRouter.ts",
+  },
+  {
+    path: "src/handlers/HandlerTypes.ts",
+    source: "src/handlers/HandlerTypes.ts",
+  },
+  {
+    path: "src/handlers/index.ts",
+    source: "src/handlers/index.ts",
+  },
+  {
+    path: "api/openapi.yml",
+    source: "api/openapi.yml",
+  },
+  {
+    path: "src/presentation/http/Responses.ts",
+    source: "src/presentation/Responses.ts",
+  },
+  {
+    path: "src/presentation/http/HttpTypes.ts",
+    source: "src/presentation/HttpTypes.ts",
+  },
+  {
+    path: "src/presentation/http/adapters.ts",
+    source: "src/presentation/adapters.ts",
+  },
+  {
+    path: "tsconfig.json",
+    source: "tsconfig.json",
+  },
+  {
+    path: ".gitignore",
+    source: ".gitignore",
+  },
+];
+
+
+export interface PackageTemplateDeps {
+  fs: typeof fs;
+  path: typeof path;
+  logger?: { info: (msg: string) => void; error: (msg: string) => void };
+}
+
+/**
+ * Copies starter files from the manifest to dist/starter-template
+ */
+export function copyStarterTemplate(
+  manifest: Manifest = defaultManifest,
+  deps: PackageTemplateDeps = {
+    fs,
+    path,
+    logger: console,
+  }
+) {
+  const { fs, path, logger } = deps;
+  const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+  const destRoot = path.resolve(projectRoot, "../../dist/starter-template");
+
+  logger?.info?.("[packageTemplate] Starting copy of starter files to dist/starter-template...");
+
+  if (!fs.existsSync(destRoot)) {
+    fs.mkdirSync(destRoot, { recursive: true });
+    logger?.info?.(`[packageTemplate] Created destination root: ${destRoot}`);
+  } else {
+    logger?.info?.(`[packageTemplate] Destination root already exists: ${destRoot}`);
+  }
+
+  for (const entry of manifest) {
+    const destPath = path.resolve(destRoot, entry.path);
+    const destDir = path.dirname(destPath);
+    if (!fs.existsSync(destDir)) {
+      fs.mkdirSync(destDir, { recursive: true });
+      logger?.info?.(`[packageTemplate] Created directory: ${destDir}`);
+    }
+    const sourcePath = path.resolve(projectRoot, "../../", entry.source);
+    if (!fs.existsSync(sourcePath)) {
+      logger?.error?.(`[packageTemplate] Source file does not exist: ${sourcePath}`);
+      throw new Error(`Source file does not exist: ${sourcePath}`);
+    }
+    fs.copyFileSync(sourcePath, destPath);
+    logger?.info?.(`[packageTemplate] Copied: ${sourcePath} -> ${destPath}`);
+  }
+  logger?.info?.(`[packageTemplate] Starter template successfully copied to ${destRoot}`);
+}
+
+
+
+// ESM-compatible main check for direct execution
+
+if (typeof process !== 'undefined' && process.argv[1]) {
+  const scriptPath = path.resolve(process.argv[1]);
+  const thisModulePath = path.resolve(fileURLToPath(import.meta.url));
+  if (scriptPath === thisModulePath) {
+    copyStarterTemplate();
+  }
+}

--- a/tests/unit/scripts/packageTemplate.spec.ts
+++ b/tests/unit/scripts/packageTemplate.spec.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { copyStarterTemplate, Manifest } from '../../../src/scripts/packageTemplate';
+
+describe('copyStarterTemplate', () => {
+  let mockFs: any;
+  let mockPath: any;
+  let mockLogger: any;
+  let manifest: Manifest;
+
+  beforeEach(() => {
+    manifest = [
+      { path: 'file1.txt', source: 'src/file1.txt' },
+      { path: 'dir/file2.txt', source: 'src/dir/file2.txt' },
+    ];
+    // existsSync: first call (destRoot) returns false, then true for all others
+    let callCount = 0;
+    mockFs = {
+      existsSync: vi.fn(() => {
+        callCount++;
+        return callCount === 1 ? false : true;
+      }),
+      mkdirSync: vi.fn(),
+      copyFileSync: vi.fn(),
+    };
+    mockPath = {
+      resolve: vi.fn((...args: string[]) => args.join('/')),
+      dirname: vi.fn((p: string) => p.split('/').slice(0, -1).join('/') || '.'),
+    };
+    mockLogger = { info: vi.fn(), error: vi.fn() };
+  });
+
+  it('copies all files from manifest to destination', () => {
+    copyStarterTemplate(manifest, { fs: mockFs, path: mockPath, logger: mockLogger });
+    // mkdirSync should be called once for destRoot
+    expect(mockFs.mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('dist/starter-template'),
+      { recursive: true }
+    );
+    expect(mockFs.copyFileSync).toHaveBeenCalledTimes(manifest.length);
+    manifest.forEach((entry) => {
+      expect(mockFs.copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining(entry.source),
+        expect.stringContaining(entry.path)
+      );
+    });
+  });
+
+  it('creates destination directories if they do not exist', () => {
+    let callCount = 0;
+    mockFs.existsSync = vi.fn(() => {
+      callCount++;
+      // 1: destRoot, 2: file1.txt dir, 3: file2.txt dir
+      return callCount === 1 ? false : callCount === 2 ? false : true;
+    });
+    copyStarterTemplate(manifest, { fs: mockFs, path: mockPath, logger: mockLogger });
+    // Should create destRoot and dir for file1.txt and dir/file2.txt
+    // Should create destRoot and at least one subdirectory
+    const mkdirCalls = mockFs.mkdirSync.mock.calls.map((call: any[]) => call[0]);
+    expect(mkdirCalls.some((p: string) => p.includes('dist/starter-template'))).toBe(true);
+    expect(mkdirCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('throws error if source file does not exist', () => {
+    mockFs.existsSync = vi.fn((p: string) => p.includes('dist/starter-template') ? true : false);
+    expect(() =>
+      copyStarterTemplate(manifest, { fs: mockFs, path: mockPath, logger: mockLogger })
+    ).toThrow(/Source file does not exist/);
+  });
+
+  it('logs info for each copied file and final message', () => {
+    copyStarterTemplate(manifest, { fs: mockFs, path: mockPath, logger: mockLogger });
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Copied:'));
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Starter template successfully copied'));
+  });
+});


### PR DESCRIPTION
This pull request refactors how starter template files are managed and copied for project initialization, improving maintainability and testability. The main change is moving the manifest and template copying logic into a new module, with corresponding updates to scripts, tests, and project setup. The build process now automatically prepares the starter template files.

**Starter template management:**

* Moved the manifest definition and template copying logic from `initProject.ts` to a new module `packageTemplate.ts`, and implemented a new `copyStarterTemplate` function to copy starter files into `dist/starter-template`. (`src/scripts/packageTemplate.ts`)
* Updated the `build` script in `package.json` to run the new template packaging step automatically via `build:template`. (`package.json`)

**Project initialization logic:**

* Refactored `initProject.ts` to import the manifest type and definition from `packageTemplate.ts`, and changed the source file resolution to always use files from `dist/starter-template`. (`src/scripts/initProject.ts`) [[1]](diffhunk://#diff-6d69c7470480ee7626d2eb4f2360a9aa223185639a18e9264755c30e66358c3cR3-R9) [[2]](diffhunk://#diff-6d69c7470480ee7626d2eb4f2360a9aa223185639a18e9264755c30e66358c3cR52-R53) [[3]](diffhunk://#diff-6d69c7470480ee7626d2eb4f2360a9aa223185639a18e9264755c30e66358c3cL69-L116)
* Updated CLI entry point to import the manifest from the new location and exported `isMainModule` for better ESM compatibility. (`src/cli.ts`) [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL3-R4) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL65-R66)

**Testing improvements:**

* Added unit tests for the new template packaging logic in `packageTemplate.spec.ts` and updated `initProject.spec.ts` to match the new file resolution strategy for starter templates. (`tests/unit/scripts/packageTemplate.spec.ts`, `tests/unit/scripts/initProject.spec.ts`) [[1]](diffhunk://#diff-f7dd9b329377d6fcf77fea4600d0b88f64b2c469ff87e08641d3e9624c5a992bR1-R76) [[2]](diffhunk://#diff-a78caa0e02b62e019caf2c378abf64286429ca68a0921e6034a7d153644e44d4R3) [[3]](diffhunk://#diff-a78caa0e02b62e019caf2c378abf64286429ca68a0921e6034a7d153644e44d4L22-R42)…uild process